### PR TITLE
Update rfsoc4x2 board part name.

### DIFF
--- a/boards/RFSoC4x2/rfsoc_radio/make_block_design.tcl
+++ b/boards/RFSoC4x2/rfsoc_radio/make_block_design.tcl
@@ -4,7 +4,7 @@ set iprepo_dir ./../../ip/iprepo
 
 # Create project
 create_project ${overlay_name} ./${overlay_name} -part xczu48dr-ffvg1517-2-e
-set_property BOARD_PART xilinx.com:rfsoc4x2:part0:1.0 [current_project]
+set_property BOARD_PART realdigital.org:rfsoc4x2:part0:1.0 [current_project]
 set_property target_language VHDL [current_project]
 
 # Set IP repository paths


### PR DESCRIPTION
Board part name for the RFSoC4x2 has changed. Users encounter an error in the make process if they have recently installed the board part.